### PR TITLE
Correctly quote files with spaces and always find bash

### DIFF
--- a/after/ftplugin/tex.vim
+++ b/after/ftplugin/tex.vim
@@ -2,7 +2,7 @@ let s:path = fnamemodify(resolve(expand('<sfile>:p')), ':h')
 
 " LatexSuite
 function! Tex_ViewLaTeX()
-  let cmd = s:path . '/../../bin/evince_backward.sh ' . fnamemodify(Tex_GetMainFileName(), ":p:r") . '.pdf ' . v:servername . ' &'
+  let cmd = s:path . '/../../bin/evince_backward.sh "' . fnamemodify(Tex_GetMainFileName(), ":p:r") . '.pdf" ' . v:servername . ' &'
   " let cmd = 'evince ' . fnamemodify(Tex_GetMainFileName(), ":p:r") . '.pdf &'
   let output = system(cmd)
 endfunction

--- a/bin/evince_backward.sh
+++ b/bin/evince_backward.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#!/usr/bin/env bash
 
 d=$(dirname $(readlink -f $0))
 


### PR DESCRIPTION
This pull request fixes the Tex_ViewLatex() function. Search from evince to GVim works, \ls doesn't yet but I have to find out why (probably a problem of paths in the synctex file because of some missing readlink -f somewhere to ensure the path is always the same: beware that full paths are stored in the synctex file, at least on my system)